### PR TITLE
Remove deprecated Worker and Client methods

### DIFF
--- a/temporaltest/server.go
+++ b/temporaltest/server.go
@@ -71,8 +71,8 @@ func (ts *TestServer) NewWorkerWithOptions(taskQueue string, registerFunc func(r
 }
 
 // DefaultClient returns the default Temporal client configured for making requests to the server.
-// It is configured to use a pre-registered test namespace and will
-// be closed on TestServer.Stop.
+//
+// It is configured to use a pre-registered test namespace and will be closed on TestServer.Stop.
 func (ts *TestServer) DefaultClient() client.Client {
 	if ts.defaultClient == nil {
 		ts.defaultClient = ts.NewClientWithOptions(ts.defaultClientOptions)
@@ -81,6 +81,7 @@ func (ts *TestServer) DefaultClient() client.Client {
 }
 
 // NewClientWithOptions returns a new Temporal client configured for making requests to the server.
+//
 // If no namespace option is set it will use a pre-registered test namespace.
 // The returned client will be closed on TestServer.Stop.
 func (ts *TestServer) NewClientWithOptions(opts client.Options) client.Client {
@@ -161,20 +162,3 @@ func NewServer(opts ...TestServerOption) *TestServer {
 
 	return &ts
 }
-
-// Worker registers and starts a Temporal worker on the specified task queue.
-// 
-// Deprecated: Use function NewWorker()
-func (ts *TestServer) Worker(taskQueue string, registerFunc func(registry worker.Registry)) worker.Worker {
-	return ts.NewWorker(taskQueue, registerFunc)
-}
-
-// Client returns a Temporal client configured for making requests to the server.
-// It is configured to use a pre-registered test namespace and will
-// be closed on TestServer.Stop.
-//
-// Deprecated: Use function DefaultClient()
-func (ts *TestServer) Client() client.Client {
-	return ts.DefaultClient()
-}
-


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This PR removes previously deprecated `Worker` and `Client` methods from the `temporaltest` package, which were replaced by `NewWorker` and `DefaultClient` respectively.

<!-- Tell your future self why have you made these changes -->
**Why?**

We're cutting a semantically versioned release soon and this avoids a future breaking change to remove deprecated APIs.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

There may be existing consumers of these APIs; they will need to modify their source code before upgrading to the first official release.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No