### PR TITLE
Set dynamic config values and default search attribute cache as disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ The UI can also be disabled via a runtime flag:
 temporalite start --headless
 ```
 
+### Dynamic Config
+
+Some advanced uses require Temporal dynamic configuration values which are usually set via a dynamic configuration file inside the Temporal configuration file. Alternatively, dynamic configuration values can be set via `--dynamic-config-value KEY=JSON_VALUE`.
+
+For example, to disable search attribute cache to make created search attributes available for use right away:
+
+```bash
+temporalite start --dynamic-config-value system.forceSearchAttributesCacheRefreshOnRead=true
+```
+
 ## Known Issues
 
 - When consuming Temporalite as a library in go mod, you may want to replace grpc-gateway with a fork to address URL escaping issue in UI. See <https://github.com/temporalio/temporalite/pull/118>

--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -37,20 +37,19 @@ var (
 )
 
 const (
-	ephemeralFlag            = "ephemeral"
-	dbPathFlag               = "filename"
-	portFlag                 = "port"
-	metricsPortFlag          = "metrics-port"
-	uiPortFlag               = "ui-port"
-	headlessFlag             = "headless"
-	ipFlag                   = "ip"
-	logFormatFlag            = "log-format"
-	logLevelFlag             = "log-level"
-	namespaceFlag            = "namespace"
-	pragmaFlag               = "sqlite-pragma"
-	configFlag               = "config"
-	dynamicConfigValueFlag   = "dynamic-config-value"
-	searchAttributeCacheFlag = "search-attribute-cache"
+	ephemeralFlag          = "ephemeral"
+	dbPathFlag             = "filename"
+	portFlag               = "port"
+	metricsPortFlag        = "metrics-port"
+	uiPortFlag             = "ui-port"
+	headlessFlag           = "headless"
+	ipFlag                 = "ip"
+	logFormatFlag          = "log-format"
+	logLevelFlag           = "log-level"
+	namespaceFlag          = "namespace"
+	pragmaFlag             = "sqlite-pragma"
+	configFlag             = "config"
+	dynamicConfigValueFlag = "dynamic-config-value"
 )
 
 func init() {
@@ -153,10 +152,6 @@ func buildCLI() *cli.App {
 				&cli.StringSliceFlag{
 					Name:  dynamicConfigValueFlag,
 					Usage: `dynamic config value, as KEY=JSON_VALUE (meaning strings need quotes)`,
-				},
-				&cli.BoolFlag{
-					Name:  searchAttributeCacheFlag,
-					Usage: `enable search attribute cache`,
 				},
 			},
 			Before: func(c *cli.Context) error {
@@ -278,14 +273,15 @@ func buildCLI() *cli.App {
 				if err != nil {
 					return err
 				}
+				// If there is no config value for search attribute cache disabling,
+				// default it to true
+				if len(configVals[dynamicconfig.ForceSearchAttributesCacheRefreshOnRead]) == 0 {
+					configVals[dynamicconfig.ForceSearchAttributesCacheRefreshOnRead] = []dynamicconfig.ConstrainedValue{
+						{Value: true},
+					}
+				}
 				for k, v := range configVals {
 					opts = append(opts, temporalite.WithDynamicConfigValue(k, v))
-				}
-
-				// We put the search attribute cache flag after dynamic config since it
-				// is essentially just a dynamic config setting internally
-				if !c.Bool(searchAttributeCacheFlag) {
-					opts = append(opts, temporalite.WithSearchAttributeCacheDisabled())
 				}
 
 				s, err := temporalite.NewServer(opts...)

--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -273,13 +273,6 @@ func buildCLI() *cli.App {
 				if err != nil {
 					return err
 				}
-				// If there is no config value for search attribute cache disabling,
-				// default it to true
-				if len(configVals[dynamicconfig.ForceSearchAttributesCacheRefreshOnRead]) == 0 {
-					configVals[dynamicconfig.ForceSearchAttributesCacheRefreshOnRead] = []dynamicconfig.ConstrainedValue{
-						{Value: true},
-					}
-				}
 				for k, v := range configVals {
 					opts = append(opts, temporalite.WithDynamicConfigValue(k, v))
 				}

--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	goLog "log"
 	"net"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/temporal"
@@ -35,18 +37,20 @@ var (
 )
 
 const (
-	ephemeralFlag   = "ephemeral"
-	dbPathFlag      = "filename"
-	portFlag        = "port"
-	metricsPortFlag = "metrics-port"
-	uiPortFlag      = "ui-port"
-	headlessFlag    = "headless"
-	ipFlag          = "ip"
-	logFormatFlag   = "log-format"
-	logLevelFlag    = "log-level"
-	namespaceFlag   = "namespace"
-	pragmaFlag      = "sqlite-pragma"
-	configFlag      = "config"
+	ephemeralFlag            = "ephemeral"
+	dbPathFlag               = "filename"
+	portFlag                 = "port"
+	metricsPortFlag          = "metrics-port"
+	uiPortFlag               = "ui-port"
+	headlessFlag             = "headless"
+	ipFlag                   = "ip"
+	logFormatFlag            = "log-format"
+	logLevelFlag             = "log-level"
+	namespaceFlag            = "namespace"
+	pragmaFlag               = "sqlite-pragma"
+	configFlag               = "config"
+	dynamicConfigValueFlag   = "dynamic-config-value"
+	searchAttributeCacheFlag = "search-attribute-cache"
 )
 
 func init() {
@@ -145,6 +149,14 @@ func buildCLI() *cli.App {
 					Usage:   `config dir path`,
 					EnvVars: []string{config.EnvKeyConfigDir},
 					Value:   "",
+				},
+				&cli.StringSliceFlag{
+					Name:  dynamicConfigValueFlag,
+					Usage: `dynamic config value, as KEY=JSON_VALUE (meaning strings need quotes)`,
+				},
+				&cli.BoolFlag{
+					Name:  searchAttributeCacheFlag,
+					Usage: `enable search attribute cache`,
 				},
 			},
 			Before: func(c *cli.Context) error {
@@ -262,6 +274,20 @@ func buildCLI() *cli.App {
 				}
 				opts = append(opts, temporalite.WithLogger(logger))
 
+				configVals, err := getDynamicConfigValues(c.StringSlice(dynamicConfigValueFlag))
+				if err != nil {
+					return err
+				}
+				for k, v := range configVals {
+					opts = append(opts, temporalite.WithDynamicConfigValue(k, v))
+				}
+
+				// We put the search attribute cache flag after dynamic config since it
+				// is essentially just a dynamic config setting internally
+				if !c.Bool(searchAttributeCacheFlag) {
+					opts = append(opts, temporalite.WithSearchAttributeCacheDisabled())
+				}
+
 				s, err := temporalite.NewServer(opts...)
 				if err != nil {
 					return err
@@ -288,4 +314,22 @@ func getPragmaMap(input []string) (map[string]string, error) {
 		result[vals[0]] = vals[1]
 	}
 	return result, nil
+}
+
+func getDynamicConfigValues(input []string) (map[dynamicconfig.Key][]dynamicconfig.ConstrainedValue, error) {
+	ret := make(map[dynamicconfig.Key][]dynamicconfig.ConstrainedValue, len(input))
+	for _, keyValStr := range input {
+		keyVal := strings.SplitN(keyValStr, "=", 2)
+		if len(keyVal) != 2 {
+			return nil, fmt.Errorf("dynamic config value not in KEY=JSON_VAL format")
+		}
+		key := dynamicconfig.Key(keyVal[0])
+		// We don't support constraints currently
+		var val dynamicconfig.ConstrainedValue
+		if err := json.Unmarshal([]byte(keyVal[1]), &val.Value); err != nil {
+			return nil, fmt.Errorf("invalid JSON value for key %q: %w", key, err)
+		}
+		ret[key] = append(ret[key], val)
+	}
+	return ret, nil
 }

--- a/cmd/temporalite/main_test.go
+++ b/cmd/temporalite/main_test.go
@@ -1,3 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
 package main
 
 import (

--- a/cmd/temporalite/main_test.go
+++ b/cmd/temporalite/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetDynamicConfigValues(t *testing.T) {
+	assertBadVal := func(v string) {
+		if _, err := getDynamicConfigValues([]string{v}); err == nil {
+			t.Fatalf("expected error for %v", v)
+		}
+	}
+	type v map[string][]interface{}
+	assertGoodVals := func(expected v, in ...string) {
+		actualVals, err := getDynamicConfigValues(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual := make(v, len(actualVals))
+		for k, vals := range actualVals {
+			for _, val := range vals {
+				actual[string(k)] = append(actual[string(k)], val.Value)
+			}
+		}
+		if !reflect.DeepEqual(expected, actual) {
+			t.Fatalf("not equal, expected - actual: %v - %v", expected, actual)
+		}
+	}
+
+	assertBadVal("foo")
+	assertBadVal("foo=")
+	assertBadVal("foo=bar")
+	assertBadVal("foo=123a")
+
+	assertGoodVals(v{"foo": {123.0}}, "foo=123")
+	assertGoodVals(
+		v{"foo": {123.0, []interface{}{"123", false}}, "bar": {"baz"}, "qux": {true}},
+		"foo=123", `bar="baz"`, "qux=true", `foo=["123", false]`,
+	)
+}

--- a/cmd/temporalite/main_test.go
+++ b/cmd/temporalite/main_test.go
@@ -1,6 +1,26 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
+// MIT License
 //
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2021 Datadog, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package main
 

--- a/internal/liteconfig/config.go
+++ b/internal/liteconfig/config.go
@@ -14,6 +14,7 @@ import (
 
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
@@ -59,6 +60,7 @@ type Config struct {
 	FrontendIP       string
 	UIServer         UIServer
 	BaseConfig       *config.Config
+	DynamicConfig    dynamicconfig.StaticClient
 }
 
 var SupportedPragmas = map[string]struct{}{

--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ package temporalite
 
 import (
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/temporal"
 
@@ -117,6 +118,26 @@ func WithBaseConfig(base *config.Config) ServerOption {
 	return newApplyFuncContainer(func(cfg *liteconfig.Config) {
 		cfg.BaseConfig = base
 	})
+}
+
+// WithDynamicConfigValue sets the given dynamic config key with the given set
+// of values. This will overwrite the key if already set.
+func WithDynamicConfigValue(key dynamicconfig.Key, value []dynamicconfig.ConstrainedValue) ServerOption {
+	return newApplyFuncContainer(func(cfg *liteconfig.Config) {
+		if cfg.DynamicConfig == nil {
+			cfg.DynamicConfig = dynamicconfig.StaticClient{}
+		}
+		cfg.DynamicConfig[key] = value
+	})
+}
+
+// WithSearchAttributeCacheDisabled disables search attribute caching. This
+// delegates to WithDynamicConfigValue.
+func WithSearchAttributeCacheDisabled() ServerOption {
+	return WithDynamicConfigValue(
+		dynamicconfig.ForceSearchAttributesCacheRefreshOnRead,
+		[]dynamicconfig.ConstrainedValue{{Value: true}},
+	)
 }
 
 type applyFuncContainer struct {

--- a/temporaltest/server.go
+++ b/temporaltest/server.go
@@ -146,6 +146,7 @@ func NewServer(opts ...TestServerOption) *TestServer {
 		temporalite.WithPersistenceDisabled(),
 		temporalite.WithDynamicPorts(),
 		temporalite.WithLogger(log.NewNoopLogger()),
+		temporalite.WithSearchAttributeCacheDisabled(),
 	)
 
 	s, err := temporalite.NewServer(ts.serverOptions...)


### PR DESCRIPTION
**What changed?**

* Added CLI and library support for setting individual dynamic config values
* Defaulted CLI (with opt-out) and test server to disable search attribute cache

**Why?**

For use with search attributes, the dev-only setting to disable cache is needed or there is a wait period before the search attributes are available for use.

This further cements that Temporalite is not for production use. This is the same config as dev docker compose at https://github.com/temporalio/docker-compose/blob/7c4f708c579cd735145e49816750ca4368ff5bf3/dynamicconfig/development-sql.yaml#L5. Any concerns here?