### PR TITLE
Fix copyright header verification mode

### DIFF
--- a/internal/copyright/header.txt
+++ b/internal/copyright/header.txt
@@ -1,5 +1,0 @@
-Unless explicitly stated otherwise all files in this repository are licensed under the MIT License.
-
-Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
-
-This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.

--- a/internal/copyright/main.go
+++ b/internal/copyright/main.go
@@ -54,7 +54,7 @@ type (
 	}
 )
 
-var headerPrefixes = []string{"The MIT License", "Unless explicitly stated"}
+var headerPrefixes = []string{"MIT License", "Unless explicitly stated"}
 
 var (
 	// directories to be excluded


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

We changed the license header, and this broke the copyright verification tool. This fixes that bug and also removes a now unused header file.