### PR TITLE
allow web UI to be configured when using mTLS in API

### DIFF
--- a/cmd/temporalite/mtls_test.go
+++ b/cmd/temporalite/mtls_test.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"testing"
 	"text/template"
@@ -144,6 +145,11 @@ func TestMTLSConfig(t *testing.T) {
 		t.Fatalf("Bad state: %v", resp.NamespaceInfo.State)
 	}
 
+	if !isUIPresent() {
+		t.Log("headless build detected, not testing temporal-ui mTLS")
+		return
+	}
+
 	// Pretend to be a browser to invoke the UI API
 	res, err := http.Get("http://localhost:11233/api/v1/namespaces?")
 	if err != nil {
@@ -157,4 +163,14 @@ func TestMTLSConfig(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("Unexpected response %s, with body %s", res.Status, string(body))
 	}
+}
+
+func isUIPresent() bool {
+	info, _ := debug.ReadBuildInfo()
+	for _, dep := range info.Deps {
+		if dep.Path == uiServerModule {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/temporalite/testdata/temporalite-ui.yaml
+++ b/cmd/temporalite/testdata/temporalite-ui.yaml
@@ -1,0 +1,5 @@
+tls:
+  caFile: dist/rootCA.pem
+  certFile: dist/client.pem
+  keyFile: dist/client-key.pem
+  serverName: local.dev

--- a/cmd/temporalite/ui_disabled.go
+++ b/cmd/temporalite/ui_disabled.go
@@ -8,6 +8,6 @@ package main
 
 import "github.com/temporalio/temporalite"
 
-func newUIOption(frontendAddr string, uiIP string, uiPort int) temporalite.ServerOption {
-	return nil
+func newUIOption(frontendAddr string, uiIP string, uiPort int, configDir string) (temporalite.ServerOption, error) {
+	return nil, nil
 }

--- a/cmd/temporalite/ui_test.go
+++ b/cmd/temporalite/ui_test.go
@@ -27,8 +27,12 @@ func TestHasUIServerDependency(t *testing.T) {
 }
 
 func TestNewUIConfig(t *testing.T) {
-	cfg := newUIConfig("localhost:7233", "localhost", 8233)
-	if err := cfg.Validate(); err != nil {
+	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "")
+	if err != nil {
+		t.Errorf("cannot create config: %s", err)
+		return
+	}
+	if err = cfg.Validate(); err != nil {
 		t.Errorf("config not valid: %s", err)
 	}
 }

--- a/cmd/temporalite/ui_test.go
+++ b/cmd/temporalite/ui_test.go
@@ -36,3 +36,28 @@ func TestNewUIConfig(t *testing.T) {
 		t.Errorf("config not valid: %s", err)
 	}
 }
+
+func TestNewUIConfigWithMissingConfigFile(t *testing.T) {
+	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "wibble")
+	if err != nil {
+		t.Errorf("cannot create config: %s", err)
+		return
+	}
+	if err = cfg.Validate(); err != nil {
+		t.Errorf("config not valid: %s", err)
+	}
+}
+
+func TestNewUIConfigWithPresentConfigFile(t *testing.T) {
+	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "testdata")
+	if err != nil {
+		t.Errorf("cannot create config: %s", err)
+		return
+	}
+	if err = cfg.Validate(); err != nil {
+		t.Errorf("config not valid: %s", err)
+	}
+	if cfg.TLS.ServerName != "local.dev" {
+		t.Errorf("did not load expected config file")
+	}
+}

--- a/internal/examples/mtls/temporalite-ui.yaml.template
+++ b/internal/examples/mtls/temporalite-ui.yaml.template
@@ -1,0 +1,4 @@
+tls:
+  caFile: {{"server-ca-cert.pem" | qualified}}
+  certFile: {{"client-cert.pem" | qualified}}
+  keyFile: {{"client-key.pem" | qualified}}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Two changes:
1. Allow temporal web/ui to be configured from a yaml file so that the web UI does not break when the API is configured for mTLS.
2. Since the UI cannot be run via HTTPS, allow the UI to be bound to a different IP than the API. This can facilitate the API with mTLS being exposed to non-local clients, while keeping the UI available to localhost.

<!-- Tell your future self why have you made these changes -->
**Why?**

Temporalite is great, and I want to use it safely in situations where I'm experimenting with mTLS in temporal, especially while implementing mTLS in workers, without the UI being broken.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Ran temporalite locally without any TLS, and with TLS certificates created by a self-signed root CA. The latter required the creation of temporalite.yaml and temporalite-ui.yaml files in a configuration directory, to allow mTLS to be set up for temporal API components, and allow the UI to make requests to the API via mTLS.

Updated the ui unit test to verify that it can still create a valid configuration when the temporalite-ui.yaml file is absent even though a config directory has been provided, and that it loads the file when it is present.

Updated the mtls test to verify proper integration between the UI and the API when mtls is enabled.

_temporalite.yaml_
```yaml
global:
  tls:
    internode:
      server:
        certFile: dist/local.dev+2-client.pem
        keyFile: dist/local.dev+2-client-key.pem
        requireClientAuth: true
        clientCaFiles:
          - dist/rootCA.pem
      client:
        serverName: local.dev
        rootCaFiles:
          - dist/rootCA.pem
    frontend:
      server:
        certFile: dist/local.dev+2-client.pem
        keyFile: dist/local.dev+2-client-key.pem
        requireClientAuth: true
        clientCaFiles:
          - dist/rootCA.pem
      client:
        serverName: local.dev
        rootCaFiles:
          - dist/rootCA.pem

# dummy values, required by yaml parser
# replaced at runtime by temporalite
persistence:
  defaultStore: default
  numHistoryShards: 1
```

_temporalite-ui.yaml_
```yaml
tls:
  caFile: dist/rootCA.pem
  certFile: dist/client.pem
  keyFile: dist/client-key.pem
  serverName: local.dev
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Applications with existing command line configuration will still work as advertised.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No.
