### PR TITLE
Test creating default db directory

### DIFF
--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -171,7 +171,7 @@ func buildCLI() *cli.App {
 				}
 
 				switch c.String(logFormatFlag) {
-				case "json", "pretty":
+				case "json", "pretty", "noop":
 				default:
 					return cli.Exit(fmt.Sprintf("bad value %q passed for flag %q", c.String(logFormatFlag), logFormatFlag), 1)
 				}
@@ -270,7 +270,8 @@ func buildCLI() *cli.App {
 				}
 
 				var logger log.Logger
-				if c.String(logFormatFlag) == "pretty" {
+				switch c.String(logFormatFlag) {
+				case "pretty":
 					lcfg := zap.NewDevelopmentConfig()
 					switch c.String(logLevelFlag) {
 					case "debug":
@@ -293,7 +294,9 @@ func buildCLI() *cli.App {
 						return err
 					}
 					logger = log.NewZapLogger(l)
-				} else {
+				case "noop":
+					logger = log.NewNoopLogger()
+				default:
 					logger = log.NewZapLogger(log.BuildZapLogger(log.Config{
 						Stdout:     true,
 						Level:      c.String(logLevelFlag),

--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -33,10 +33,6 @@ import (
 // as a dependency when building with the `headless` tag enabled.
 const uiServerModule = "github.com/temporalio/ui-server/v2"
 
-var (
-	defaultCfg *liteconfig.Config
-)
-
 const (
 	ephemeralFlag          = "ephemeral"
 	dbPathFlag             = "filename"
@@ -54,10 +50,6 @@ const (
 	dynamicConfigValueFlag = "dynamic-config-value"
 )
 
-func init() {
-	defaultCfg, _ = liteconfig.NewDefaultConfig()
-}
-
 func main() {
 	if err := buildCLI().Run(os.Args); err != nil {
 		goLog.Fatal(err)
@@ -68,6 +60,8 @@ func main() {
 var version string
 
 func buildCLI() *cli.App {
+	defaultCfg, _ := liteconfig.NewDefaultConfig()
+
 	if version == "" {
 		version = "(devel)"
 	}

--- a/cmd/temporalite/main_test.go
+++ b/cmd/temporalite/main_test.go
@@ -144,7 +144,7 @@ func TestCreateDataDirectory(t *testing.T) {
 
 		go func() {
 			if err := buildCLI().RunContext(ctx, args); err != nil {
-				t.Error(err)
+				t.Log(err)
 			}
 		}()
 
@@ -185,7 +185,7 @@ func TestCreateDataDirectory(t *testing.T) {
 
 		go func() {
 			if err := buildCLI().RunContext(ctx, args); err != nil {
-				t.Error(err)
+				t.Log(err)
 			}
 		}()
 

--- a/cmd/temporalite/main_test.go
+++ b/cmd/temporalite/main_test.go
@@ -133,14 +133,14 @@ func assertServerHealth(t *testing.T, ctx context.Context, opts client.Options) 
 
 func TestCreateDataDirectory(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer func() {
-		cancel()
-		// Give Temporal servers a little time to shut down before temp test
-		// directory is cleaned up.
-		time.Sleep(1000 * time.Millisecond)
-	}()
+	defer cancel()
 
-	testUserHome := t.TempDir()
+	testUserHome := filepath.Join(os.TempDir(), "temporalite_test", t.Name())
+	t.Cleanup(func() {
+		if err := os.RemoveAll(testUserHome); err != nil {
+			fmt.Println("error cleaning up temp dir:", err)
+		}
+	})
 	// Set user home for all supported operating systems
 	t.Setenv("AppData", testUserHome)         // Windows
 	t.Setenv("HOME", testUserHome)            // macOS

--- a/cmd/temporalite/main_test.go
+++ b/cmd/temporalite/main_test.go
@@ -82,7 +82,7 @@ func newServerAndClientOpts(port int, customArgs ...string) ([]string, client.Op
 		"temporalite",
 		"start",
 		"--namespace", "default",
-		"--log-level", "error",
+		"--log-format", "noop",
 		"--headless",
 		"--port", strconv.Itoa(port),
 	}

--- a/cmd/temporalite/mtls_test.go
+++ b/cmd/temporalite/mtls_test.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -43,6 +44,8 @@ import (
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
+
+	"github.com/temporalio/temporalite/internal/liteconfig"
 )
 
 func TestMTLSConfig(t *testing.T) {
@@ -82,6 +85,10 @@ func TestMTLSConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	portProvider := liteconfig.NewPortProvider()
+	port := portProvider.MustGetFreePort()
+	portProvider.Close()
+
 	// Run ephemerally using temp config
 	args := []string{
 		"temporalite",
@@ -91,7 +98,7 @@ func TestMTLSConfig(t *testing.T) {
 		"--namespace", "default",
 		"--log-format", "pretty",
 		"--log-level", "error",
-		"--port", "10233",
+		"--port", strconv.Itoa(port),
 	}
 	go func() {
 		if err := buildCLI().RunContext(ctx, args); err != nil {
@@ -117,7 +124,7 @@ func TestMTLSConfig(t *testing.T) {
 
 	// Build client options and try to connect client every 100ms for 5s
 	options := client.Options{
-		HostPort: "localhost:10233",
+		HostPort: fmt.Sprintf("localhost:%d", port),
 		ConnectionOptions: client.ConnectionOptions{
 			TLS: &tls.Config{
 				Certificates: []tls.Certificate{clientCert},
@@ -152,7 +159,7 @@ func TestMTLSConfig(t *testing.T) {
 	}
 
 	// Pretend to be a browser to invoke the UI API
-	res, err := http.Get("http://localhost:11233/api/v1/namespaces?")
+	res, err := http.Get(fmt.Sprintf("http://localhost:%d/api/v1/namespaces?", port+1000))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/temporalite/mtls_test.go
+++ b/cmd/temporalite/mtls_test.go
@@ -82,7 +82,10 @@ func TestMTLSConfig(t *testing.T) {
 	}
 
 	portProvider := liteconfig.NewPortProvider()
-	port := portProvider.MustGetFreePort()
+	var (
+		frontendPort = portProvider.MustGetFreePort()
+		webUIPort    = portProvider.MustGetFreePort()
+	)
 	portProvider.Close()
 
 	// Run ephemerally using temp config
@@ -94,7 +97,8 @@ func TestMTLSConfig(t *testing.T) {
 		"--namespace", "default",
 		"--log-format", "pretty",
 		"--log-level", "error",
-		"--port", strconv.Itoa(port),
+		"--port", strconv.Itoa(frontendPort),
+		"--ui-port", strconv.Itoa(webUIPort),
 	}
 	go func() {
 		if err := buildCLI().RunContext(ctx, args); err != nil {
@@ -120,7 +124,7 @@ func TestMTLSConfig(t *testing.T) {
 
 	// Build client options and try to connect client every 100ms for 5s
 	options := client.Options{
-		HostPort: fmt.Sprintf("localhost:%d", port),
+		HostPort: fmt.Sprintf("localhost:%d", frontendPort),
 		ConnectionOptions: client.ConnectionOptions{
 			TLS: &tls.Config{
 				Certificates: []tls.Certificate{clientCert},
@@ -155,7 +159,7 @@ func TestMTLSConfig(t *testing.T) {
 	}
 
 	// Pretend to be a browser to invoke the UI API
-	res, err := http.Get(fmt.Sprintf("http://localhost:%d/api/v1/namespaces?", port+1000))
+	res, err := http.Get(fmt.Sprintf("http://localhost:%d/api/v1/namespaces?", webUIPort))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/temporalite/mtls_test.go
+++ b/cmd/temporalite/mtls_test.go
@@ -55,11 +55,7 @@ func TestMTLSConfig(t *testing.T) {
 	mtlsDir := filepath.Join(thisFile, "../../../internal/examples/mtls")
 
 	// Create temp config dir
-	confDir, err := os.MkdirTemp("", "temporalite-conf-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(confDir)
+	confDir := t.TempDir()
 
 	// Run templated config and put in temp dir
 	var buf bytes.Buffer

--- a/cmd/temporalite/mtls_test.go
+++ b/cmd/temporalite/mtls_test.go
@@ -41,6 +41,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/urfave/cli/v2"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
@@ -101,8 +102,12 @@ func TestMTLSConfig(t *testing.T) {
 		"--ui-port", strconv.Itoa(webUIPort),
 	}
 	go func() {
-		if err := buildCLI().RunContext(ctx, args); err != nil {
-			t.Logf("CLI failed: %v", err)
+		temporaliteCLI := buildCLI()
+		// Don't call os.Exit
+		temporaliteCLI.ExitErrHandler = func(_ *cli.Context, _ error) {}
+
+		if err := temporaliteCLI.RunContext(ctx, args); err != nil {
+			fmt.Printf("CLI failed: %s\n", err)
 		}
 	}()
 

--- a/cmd/temporalite/mtls_test.go
+++ b/cmd/temporalite/mtls_test.go
@@ -96,8 +96,7 @@ func TestMTLSConfig(t *testing.T) {
 		"--ephemeral",
 		"--config", confDir,
 		"--namespace", "default",
-		"--log-format", "pretty",
-		"--log-level", "error",
+		"--log-format", "noop",
 		"--port", strconv.Itoa(frontendPort),
 		"--ui-port", strconv.Itoa(webUIPort),
 	}

--- a/cmd/temporalite/mtls_test.go
+++ b/cmd/temporalite/mtls_test.go
@@ -90,6 +90,7 @@ func TestMTLSConfig(t *testing.T) {
 		"--config", confDir,
 		"--namespace", "default",
 		"--log-format", "pretty",
+		"--log-level", "error",
 		"--port", "10233",
 	}
 	go func() {

--- a/internal/liteconfig/freeport.go
+++ b/internal/liteconfig/freeport.go
@@ -11,12 +11,16 @@ import (
 
 // Modified from https://github.com/phayes/freeport/blob/95f893ade6f232a5f1511d61735d89b1ae2df543/freeport.go
 
-type portProvider struct {
+func NewPortProvider() *PortProvider {
+	return &PortProvider{}
+}
+
+type PortProvider struct {
 	listeners []*net.TCPListener
 }
 
-// getFreePort asks the kernel for a free open port that is ready to use.
-func (p *portProvider) getFreePort() (int, error) {
+// GetFreePort asks the kernel for a free open port that is ready to use.
+func (p *PortProvider) GetFreePort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		if addr, err = net.ResolveTCPAddr("tcp6", "[::1]:0"); err != nil {
@@ -34,15 +38,15 @@ func (p *portProvider) getFreePort() (int, error) {
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
-func (p *portProvider) mustGetFreePort() int {
-	port, err := p.getFreePort()
+func (p *PortProvider) MustGetFreePort() int {
+	port, err := p.GetFreePort()
 	if err != nil {
 		panic(err)
 	}
 	return port
 }
 
-func (p *portProvider) close() error {
+func (p *PortProvider) Close() error {
 	for _, l := range p.listeners {
 		if err := l.Close(); err != nil {
 			return err

--- a/temporaltest/server.go
+++ b/temporaltest/server.go
@@ -92,7 +92,7 @@ func (ts *TestServer) NewClientWithOptions(opts client.Options) client.Client {
 		opts.Logger = &testLogger{ts.t}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	c, err := ts.server.NewClientWithOptions(ctx, opts)

--- a/temporaltest/server_test.go
+++ b/temporaltest/server_test.go
@@ -61,7 +61,7 @@ func TestNewServer(t *testing.T) {
 		helloworld.RegisterWorkflowsAndActivities(registry)
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	wfr, err := ts.DefaultClient().ExecuteWorkflow(
@@ -98,7 +98,7 @@ func TestNewWorkerWithOptions(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	wfr, err := ts.DefaultClient().ExecuteWorkflow(
@@ -136,7 +136,7 @@ func TestDefaultWorkerOptions(t *testing.T) {
 	ts.NewWorker("hello_world", func(registry worker.Registry) {
 		helloworld.RegisterWorkflowsAndActivities(registry)
 	})
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	wfr, err := ts.DefaultClient().ExecuteWorkflow(
@@ -174,7 +174,7 @@ func TestClientWithDefaultInterceptor(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	wfr, err := ts.DefaultClient().ExecuteWorkflow(
@@ -198,7 +198,7 @@ func TestClientWithDefaultInterceptor(t *testing.T) {
 }
 
 func TestSearchAttributeCacheDisabled(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	ts := temporaltest.NewServer(temporaltest.WithT(t))
 
@@ -233,7 +233,7 @@ func BenchmarkRunWorkflow(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		func(b *testing.B) {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
 			wfr, err := c.ExecuteWorkflow(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This PR adds test cases for creating the default data directory when it doesn't already exist, returning an error when a custom db path is configured in a missing directory, and starting the server with a custom db path in an existing directory.

I've also removed panic logs in integration tests and increased timeouts in an attempt to decrease test flakiness. This was done with a new `--log-format noop` flag value.

<!-- Tell your future self why have you made these changes -->
**Why?**

This is basic behavior that I believe should be validated with an integration test. The test case for starting Temporal server with a default db path will also catch any breaking change that updates the default path.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

CI

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

I noticed a whole host of race conditions in the integration tests during development. Most have been quashed, however we should be on the lookout for new flakiness introduced by these test cases.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No
