### PR TITLE
Expose a new --codec-endpoint flag to start command

### DIFF
--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -42,6 +42,7 @@ const (
 	headlessFlag           = "headless"
 	ipFlag                 = "ip"
 	uiIPFlag               = "ui-ip"
+	uiCodecEndpointFlag    = "ui-codec-endpoint"
 	logFormatFlag          = "log-format"
 	logLevelFlag           = "log-level"
 	namespaceFlag          = "namespace"
@@ -125,6 +126,11 @@ func buildCLI() *cli.App {
 					DefaultText: "same as --ip (eg. 127.0.0.1)",
 				},
 				&cli.StringFlag{
+					Name:    uiCodecEndpointFlag,
+					Usage:   `UI Remote data converter HTTP endpoint`,
+					EnvVars: nil,
+				},
+				&cli.StringFlag{
 					Name:    logFormatFlag,
 					Usage:   `customize the log formatting (allowed: ["json" "pretty"])`,
 					EnvVars: nil,
@@ -198,11 +204,12 @@ func buildCLI() *cli.App {
 			},
 			Action: func(c *cli.Context) error {
 				var (
-					ip          = c.String(ipFlag)
-					serverPort  = c.Int(portFlag)
-					metricsPort = c.Int(metricsPortFlag)
-					uiPort      = serverPort + 1000
-					uiIP        = ip
+					ip            = c.String(ipFlag)
+					serverPort    = c.Int(portFlag)
+					metricsPort   = c.Int(metricsPortFlag)
+					uiPort        = serverPort + 1000
+					uiIP          = ip
+					codecEndpoint = ""
 				)
 
 				if c.IsSet(uiPortFlag) {
@@ -211,6 +218,10 @@ func buildCLI() *cli.App {
 
 				if c.IsSet(uiIPFlag) {
 					uiIP = c.String(uiIPFlag)
+				}
+
+				if c.IsSet(uiCodecEndpointFlag) {
+					codecEndpoint = c.String(uiCodecEndpointFlag)
 				}
 
 				pragmas, err := getPragmaMap(c.StringSlice(pragmaFlag))
@@ -257,7 +268,7 @@ func buildCLI() *cli.App {
 				}
 				if !c.Bool(headlessFlag) {
 					frontendAddr := fmt.Sprintf("%s:%d", ip, serverPort)
-					opt, err := newUIOption(frontendAddr, uiIP, uiPort, c.String(configFlag))
+					opt, err := newUIOption(frontendAddr, uiIP, uiPort, codecEndpoint, c.String(configFlag))
 					if err != nil {
 						return err
 					}

--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	uiconfig "github.com/temporalio/ui-server/v2/server/config"
 	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -204,12 +205,12 @@ func buildCLI() *cli.App {
 			},
 			Action: func(c *cli.Context) error {
 				var (
-					ip            = c.String(ipFlag)
-					serverPort    = c.Int(portFlag)
-					metricsPort   = c.Int(metricsPortFlag)
-					uiPort        = serverPort + 1000
-					uiIP          = ip
-					codecEndpoint = ""
+					ip              = c.String(ipFlag)
+					serverPort      = c.Int(portFlag)
+					metricsPort     = c.Int(metricsPortFlag)
+					uiPort          = serverPort + 1000
+					uiIP            = ip
+					uiCodecEndpoint = ""
 				)
 
 				if c.IsSet(uiPortFlag) {
@@ -221,7 +222,7 @@ func buildCLI() *cli.App {
 				}
 
 				if c.IsSet(uiCodecEndpointFlag) {
-					codecEndpoint = c.String(uiCodecEndpointFlag)
+					uiCodecEndpoint = c.String(uiCodecEndpointFlag)
 				}
 
 				pragmas, err := getPragmaMap(c.StringSlice(pragmaFlag))
@@ -268,7 +269,17 @@ func buildCLI() *cli.App {
 				}
 				if !c.Bool(headlessFlag) {
 					frontendAddr := fmt.Sprintf("%s:%d", ip, serverPort)
-					opt, err := newUIOption(frontendAddr, uiIP, uiPort, codecEndpoint, c.String(configFlag))
+					cfg := &uiconfig.Config{
+						Host:                uiIP,
+						Port:                uiPort,
+						TemporalGRPCAddress: frontendAddr,
+						EnableUI:            true,
+						Codec: uiconfig.Codec{
+							Endpoint: uiCodecEndpoint,
+						},
+					}
+
+					opt, err := newUIOption(cfg, c.String(configFlag))
 					if err != nil {
 						return err
 					}

--- a/cmd/temporalite/main.go
+++ b/cmd/temporalite/main.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	uiconfig "github.com/temporalio/ui-server/v2/server/config"
 	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -51,6 +50,14 @@ const (
 	configFlag             = "config"
 	dynamicConfigValueFlag = "dynamic-config-value"
 )
+
+type uiConfig struct {
+	Host                string
+	Port                int
+	TemporalGRPCAddress string
+	EnableUI            bool
+	CodecEndpoint       string
+}
 
 func main() {
 	if err := buildCLI().Run(os.Args); err != nil {
@@ -269,14 +276,12 @@ func buildCLI() *cli.App {
 				}
 				if !c.Bool(headlessFlag) {
 					frontendAddr := fmt.Sprintf("%s:%d", ip, serverPort)
-					cfg := &uiconfig.Config{
+					cfg := &uiConfig{
 						Host:                uiIP,
 						Port:                uiPort,
 						TemporalGRPCAddress: frontendAddr,
 						EnableUI:            true,
-						Codec: uiconfig.Codec{
-							Endpoint: uiCodecEndpoint,
-						},
+						CodecEndpoint:       uiCodecEndpoint,
 					}
 
 					opt, err := newUIOption(cfg, c.String(configFlag))

--- a/cmd/temporalite/ui.go
+++ b/cmd/temporalite/ui.go
@@ -31,6 +31,9 @@ func newUIOption(c *uiconfig.Config, configDir string) (temporalite.ServerOption
 }
 
 func newUIConfig(cfg *uiconfig.Config, configDir string) (*uiconfig.Config, error) {
+	frontendAddr := cfg.TemporalGRPCAddress
+	enabledUi := cfg.EnableUI
+
 	if configDir != "" {
 		if err := provider.Load(configDir, cfg, "temporalite-ui"); err != nil {
 			if !strings.HasPrefix(err.Error(), "no config files found") {
@@ -38,5 +41,11 @@ func newUIConfig(cfg *uiconfig.Config, configDir string) (*uiconfig.Config, erro
 			}
 		}
 	}
+
+	// See https://github.com/temporalio/temporalite/pull/174/files#r1035958308
+	// for context about those overrides.
+	cfg.TemporalGRPCAddress = frontendAddr
+	cfg.EnableUI = enabledUi
+
 	return cfg, nil
 }

--- a/cmd/temporalite/ui.go
+++ b/cmd/temporalite/ui.go
@@ -19,11 +19,12 @@ import (
 	"github.com/temporalio/temporalite"
 )
 
-func newUIOption(frontendAddr string, uiIP string, uiPort int, configDir string) (temporalite.ServerOption, error) {
+func newUIOption(frontendAddr string, uiIP string, uiPort int, codecEndpoint string, configDir string) (temporalite.ServerOption, error) {
 	cfg, err := newUIConfig(
 		frontendAddr,
 		uiIP,
 		uiPort,
+		codecEndpoint,
 		configDir,
 	)
 	if err != nil {
@@ -32,10 +33,13 @@ func newUIOption(frontendAddr string, uiIP string, uiPort int, configDir string)
 	return temporalite.WithUI(uiserver.NewServer(uiserveroptions.WithConfigProvider(cfg))), nil
 }
 
-func newUIConfig(frontendAddr string, uiIP string, uiPort int, configDir string) (*uiconfig.Config, error) {
+func newUIConfig(frontendAddr string, uiIP string, uiPort int, codecEndpoint string, configDir string) (*uiconfig.Config, error) {
 	cfg := &uiconfig.Config{
 		Host: uiIP,
 		Port: uiPort,
+		Codec: uiconfig.Codec{
+			Endpoint: codecEndpoint,
+		},
 	}
 	if configDir != "" {
 		if err := provider.Load(configDir, cfg, "temporalite-ui"); err != nil {

--- a/cmd/temporalite/ui.go
+++ b/cmd/temporalite/ui.go
@@ -19,7 +19,7 @@ import (
 	"github.com/temporalio/temporalite"
 )
 
-func newUIOption(c *uiconfig.Config, configDir string) (temporalite.ServerOption, error) {
+func newUIOption(c *uiConfig, configDir string) (temporalite.ServerOption, error) {
 	cfg, err := newUIConfig(
 		c,
 		configDir,
@@ -30,9 +30,16 @@ func newUIOption(c *uiconfig.Config, configDir string) (temporalite.ServerOption
 	return temporalite.WithUI(uiserver.NewServer(uiserveroptions.WithConfigProvider(cfg))), nil
 }
 
-func newUIConfig(cfg *uiconfig.Config, configDir string) (*uiconfig.Config, error) {
-	frontendAddr := cfg.TemporalGRPCAddress
-	enabledUi := cfg.EnableUI
+func newUIConfig(c *uiConfig, configDir string) (*uiconfig.Config, error) {
+	cfg := &uiconfig.Config{
+		Host:                c.Host,
+		Port:                c.Port,
+		TemporalGRPCAddress: c.TemporalGRPCAddress,
+		EnableUI:            c.EnableUI,
+		Codec: uiconfig.Codec{
+			Endpoint: c.CodecEndpoint,
+		},
+	}
 
 	if configDir != "" {
 		if err := provider.Load(configDir, cfg, "temporalite-ui"); err != nil {
@@ -44,8 +51,8 @@ func newUIConfig(cfg *uiconfig.Config, configDir string) (*uiconfig.Config, erro
 
 	// See https://github.com/temporalio/temporalite/pull/174/files#r1035958308
 	// for context about those overrides.
-	cfg.TemporalGRPCAddress = frontendAddr
-	cfg.EnableUI = enabledUi
+	cfg.TemporalGRPCAddress = c.TemporalGRPCAddress
+	cfg.EnableUI = c.EnableUI
 
 	return cfg, nil
 }

--- a/cmd/temporalite/ui.go
+++ b/cmd/temporalite/ui.go
@@ -19,12 +19,9 @@ import (
 	"github.com/temporalio/temporalite"
 )
 
-func newUIOption(frontendAddr string, uiIP string, uiPort int, codecEndpoint string, configDir string) (temporalite.ServerOption, error) {
+func newUIOption(c *uiconfig.Config, configDir string) (temporalite.ServerOption, error) {
 	cfg, err := newUIConfig(
-		frontendAddr,
-		uiIP,
-		uiPort,
-		codecEndpoint,
+		c,
 		configDir,
 	)
 	if err != nil {
@@ -33,14 +30,7 @@ func newUIOption(frontendAddr string, uiIP string, uiPort int, codecEndpoint str
 	return temporalite.WithUI(uiserver.NewServer(uiserveroptions.WithConfigProvider(cfg))), nil
 }
 
-func newUIConfig(frontendAddr string, uiIP string, uiPort int, codecEndpoint string, configDir string) (*uiconfig.Config, error) {
-	cfg := &uiconfig.Config{
-		Host: uiIP,
-		Port: uiPort,
-		Codec: uiconfig.Codec{
-			Endpoint: codecEndpoint,
-		},
-	}
+func newUIConfig(cfg *uiconfig.Config, configDir string) (*uiconfig.Config, error) {
 	if configDir != "" {
 		if err := provider.Load(configDir, cfg, "temporalite-ui"); err != nil {
 			if !strings.HasPrefix(err.Error(), "no config files found") {
@@ -48,7 +38,5 @@ func newUIConfig(frontendAddr string, uiIP string, uiPort int, codecEndpoint str
 			}
 		}
 	}
-	cfg.TemporalGRPCAddress = frontendAddr
-	cfg.EnableUI = true
 	return cfg, nil
 }

--- a/cmd/temporalite/ui_disabled.go
+++ b/cmd/temporalite/ui_disabled.go
@@ -6,12 +6,8 @@
 
 package main
 
-import (
-	uiconfig "github.com/temporalio/ui-server/v2/server/config"
+import "github.com/temporalio/temporalite"
 
-	"github.com/temporalio/temporalite"
-)
-
-func newUIOption(c *uiconfig.Config, configDir string) (temporalite.ServerOption, error) {
+func newUIOption(c *uiConfig, configDir string) (temporalite.ServerOption, error) {
 	return nil, nil
 }

--- a/cmd/temporalite/ui_disabled.go
+++ b/cmd/temporalite/ui_disabled.go
@@ -6,8 +6,12 @@
 
 package main
 
-import "github.com/temporalio/temporalite"
+import (
+	uiconfig "github.com/temporalio/ui-server/v2/server/config"
 
-func newUIOption(frontendAddr string, uiIP string, uiPort int, configDir string) (temporalite.ServerOption, error) {
+	"github.com/temporalio/temporalite"
+)
+
+func newUIOption(c *uiconfig.Config, configDir string) (temporalite.ServerOption, error) {
 	return nil, nil
 }

--- a/cmd/temporalite/ui_test.go
+++ b/cmd/temporalite/ui_test.go
@@ -9,8 +9,6 @@ package main
 import (
 	"runtime/debug"
 	"testing"
-
-	uiconfig "github.com/temporalio/ui-server/v2/server/config"
 )
 
 // This test ensures that ui-server is a dependency of Temporalite built in non-headless mode.
@@ -29,7 +27,7 @@ func TestHasUIServerDependency(t *testing.T) {
 }
 
 func TestNewUIConfig(t *testing.T) {
-	c := &uiconfig.Config{
+	c := &uiConfig{
 		Host:                "localhost",
 		Port:                8233,
 		TemporalGRPCAddress: "localhost:7233",
@@ -46,7 +44,7 @@ func TestNewUIConfig(t *testing.T) {
 }
 
 func TestNewUIConfigWithMissingConfigFile(t *testing.T) {
-	c := &uiconfig.Config{
+	c := &uiConfig{
 		Host:                "localhost",
 		Port:                8233,
 		TemporalGRPCAddress: "localhost:7233",
@@ -63,7 +61,7 @@ func TestNewUIConfigWithMissingConfigFile(t *testing.T) {
 }
 
 func TestNewUIConfigWithPresentConfigFile(t *testing.T) {
-	c := &uiconfig.Config{
+	c := &uiConfig{
 		Host:                "localhost",
 		Port:                8233,
 		TemporalGRPCAddress: "localhost:7233",

--- a/cmd/temporalite/ui_test.go
+++ b/cmd/temporalite/ui_test.go
@@ -27,7 +27,7 @@ func TestHasUIServerDependency(t *testing.T) {
 }
 
 func TestNewUIConfig(t *testing.T) {
-	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "")
+	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "", "")
 	if err != nil {
 		t.Errorf("cannot create config: %s", err)
 		return
@@ -38,7 +38,7 @@ func TestNewUIConfig(t *testing.T) {
 }
 
 func TestNewUIConfigWithMissingConfigFile(t *testing.T) {
-	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "wibble")
+	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "", "wibble")
 	if err != nil {
 		t.Errorf("cannot create config: %s", err)
 		return
@@ -49,7 +49,7 @@ func TestNewUIConfigWithMissingConfigFile(t *testing.T) {
 }
 
 func TestNewUIConfigWithPresentConfigFile(t *testing.T) {
-	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "testdata")
+	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "", "testdata")
 	if err != nil {
 		t.Errorf("cannot create config: %s", err)
 		return

--- a/cmd/temporalite/ui_test.go
+++ b/cmd/temporalite/ui_test.go
@@ -9,6 +9,8 @@ package main
 import (
 	"runtime/debug"
 	"testing"
+
+	uiconfig "github.com/temporalio/ui-server/v2/server/config"
 )
 
 // This test ensures that ui-server is a dependency of Temporalite built in non-headless mode.
@@ -27,7 +29,13 @@ func TestHasUIServerDependency(t *testing.T) {
 }
 
 func TestNewUIConfig(t *testing.T) {
-	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "", "")
+	c := &uiconfig.Config{
+		Host:                "localhost",
+		Port:                8233,
+		TemporalGRPCAddress: "localhost:7233",
+		EnableUI:            true,
+	}
+	cfg, err := newUIConfig(c, "")
 	if err != nil {
 		t.Errorf("cannot create config: %s", err)
 		return
@@ -38,7 +46,13 @@ func TestNewUIConfig(t *testing.T) {
 }
 
 func TestNewUIConfigWithMissingConfigFile(t *testing.T) {
-	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "", "wibble")
+	c := &uiconfig.Config{
+		Host:                "localhost",
+		Port:                8233,
+		TemporalGRPCAddress: "localhost:7233",
+		EnableUI:            true,
+	}
+	cfg, err := newUIConfig(c, "wibble")
 	if err != nil {
 		t.Errorf("cannot create config: %s", err)
 		return
@@ -49,7 +63,13 @@ func TestNewUIConfigWithMissingConfigFile(t *testing.T) {
 }
 
 func TestNewUIConfigWithPresentConfigFile(t *testing.T) {
-	cfg, err := newUIConfig("localhost:7233", "localhost", 8233, "", "testdata")
+	c := &uiconfig.Config{
+		Host:                "localhost",
+		Port:                8233,
+		TemporalGRPCAddress: "localhost:7233",
+		EnableUI:            true,
+	}
+	cfg, err := newUIConfig(c, "testdata")
 	if err != nil {
 		t.Errorf("cannot create config: %s", err)
 		return


### PR DESCRIPTION
This allows starting a temporalite instance with a remote data converter endpoint preconfigured.

<!-- Describe what has changed in this PR -->
**What changed?**

Adds a new `--ui-codec-endpoint` flag to `temporalite start`.

<!-- Tell your future self why have you made these changes -->
**Why?**

Exposing the flag allows to send a single command to run to users that can rely on a remote data converter hosted somewhere instead of telling them to run 2 processes on their laptop.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Manually

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No
