### PR TITLE
Fix Codecov badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/temporalio/temporalite.svg)](https://pkg.go.dev/github.com/temporalio/temporalite)
 [![ci](https://github.com/temporalio/temporalite/actions/workflows/ci.yml/badge.svg)](https://github.com/temporalio/temporalite/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/DataDog/temporalite/branch/main/graph/badge.svg)](https://codecov.io/gh/DataDog/temporalite)
+[![codecov](https://codecov.io/gh/temporalio/temporalite/branch/main/graph/badge.svg)](https://codecov.io/gh/temporalio/temporalite)
 
 > ⚠️ This project is experimental and not suitable for production use. ⚠️
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updated the `codecov` badge in the README from `DataDog/temporalite` to `temporalio/temporalite`

<!-- Tell your future self why have you made these changes -->
**Why?**
I noticed the codecov badge was showing `unknown`, but there is data for the repository in the current org

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Viewed the badge at the updated url, also visible here:
[![codecov](https://codecov.io/gh/temporalio/temporalite/branch/main/graph/badge.svg)](https://codecov.io/gh/temporalio/temporalite)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Only change is to README - should be very low risk

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No